### PR TITLE
Initial PR for narrow ("portrait mode") tweaks.

### DIFF
--- a/UnShittifyNarrowWindow.theme.css
+++ b/UnShittifyNarrowWindow.theme.css
@@ -1,0 +1,90 @@
+/**
+ * @name UnShittifyNarrowWindow
+ * @author Xaero252
+ * @description Tweak screen space utilization on the titlebar for narrow window users
+ * @version 0.0.1
+ */
+
+/* -----------------  UN-SHITIFY DISCORD ------------------- *//*
+
+/* 
+ *	This has a lot of ugly hardcoded pixel values around the default discord theme
+ *	Ideally, we can rely on css variables for tweaking this stuff, but many things aren't defined or are adjusted by javascript.
+ *	It's difficult to make this a toggle-by-setting option, since @ rules are global and can't see css custom properties.
+ */
+
+/* Some easily accessible user-tunables. */
+:root {
+	--toolbox-collapse-delay: 0.5s;
+	--toolbox-width: 115px;
+	--toolbox-padding: calc(var(--toolbox-width) + 15px);
+	--search-max-width: calc(25vw - (var(--toolbox-width)));
+}
+
+/* You probably don't want to edit anything below here */
+@media all and (max-width: 1280px) {
+
+   /* Permanent Expansion States */
+	:root:has(.trailing_c38106 [aria-label="Update Ready!"]), :root:has(.trailing_c38106 .selected__9293f) {
+		--toolbox-width: 205px !important;
+		--toolbox-collapse-delay: 0s !important;
+   }
+
+   /* Hover Expansion */
+	:root:has(.trailing_c38106:hover) {
+		--toolbox-width: 205px;
+		--toolbox-collapse-delay: 0.5s;
+   }
+
+   /* Toolbox Container */
+	.trailing_c38106 {
+		width: var(--toolbox-width);
+		overflow: hidden;
+		transition: width 0.2s ease var(--toolbox-collapse-delay);
+		will-change: width;
+   }
+
+   /* Title Synchronization */
+	.title_f75fb0 {
+		padding-right: var(--toolbox-padding) !important;
+		transition: padding-right 0.2s ease var(--toolbox-collapse-delay);
+   }
+
+   /* Search Bar Animation Sync */
+	.public-DraftEditor-content {
+		min-width: 5vw;
+		max-width: var(--search-max-width);
+		transition: max-width 0.2s ease var(--toolbox-collapse-delay);
+   }
+
+   /* Immediate Response for Special States */
+	:root:has(.trailing_c38106 [aria-label="Update Ready!"]) .title_f75fb0, :root:has(.trailing_c38106 .selected__9293f) .title_f75fb0 {
+		transition: padding-right 0.2s ease 0s !important;
+   }
+
+	:root:has(.trailing_c38106 [aria-label="Update Ready!"]) .public-DraftEditor-content, :root:has(.trailing_c38106 .selected__9293f) .public-DraftEditor-content {
+		transition: max-width 0.2s ease 0s !important;
+   }
+
+   /* Combined States */
+	:root:has(.trailing_c38106 .selected__9293f):has(.trailing_c38106:hover), :root:has(.trailing_c38106 [aria-label="Update Ready!"]):has(.trailing_c38106:hover) {
+		--toolbox-width: 205px !important;
+   }
+
+   /* Delayed Closing */
+	.trailing_c38106:not(:hover):not(:has([aria-label="Update Ready!"])):not(:has(.selected__9293f)) {
+		--toolbox-collapse-delay: 0.5s;
+   }
+}
+
+/* Search Bar Rules */
+.public-DraftEditor-content:not(:focus) {
+	width: 5vw;
+	transition: width 0.2s ease, max-width 0.2s ease !important;
+}
+
+.public-DraftEditor-content:focus {
+	width: auto;
+	max-width: var(--search-max-width);
+	transition: max-width 0.2s ease var(--toolbox-collapse-delay), width 0.2s ease !important;
+}


### PR DESCRIPTION
This adds some additional tweaks specifically for narrow "portrait mode" windows in a separate .theme.css file. It's kind of difficult to add these behind a setting since media rules are at the global scope and don't see custom properties. Users could just add this as another `@include` rule or another theme source in say, vencord.

Things this does:

- Dynamically hides and shows the toolbox. There is a delay in both showing and hiding the toolbox, so that "accidental" interaction doesn't cause problems.
- The toolbox will always be shown while the Inbox is open, or when there is an update available for Discord
- Dynamically resizes the Search Bar to better maximize screen space usage. The search bar has a maximum constraint, and will collapse when not in focus.

Here's a preview of the current state of this theme file:

https://github.com/user-attachments/assets/199a6f6b-9fee-4b88-9fe8-ab641d52f1f8


