### PR TITLE
fix: OS nav buttons overlapping alert

### DIFF
--- a/UnShittifySource.theme.css
+++ b/UnShittifySource.theme.css
@@ -43,6 +43,11 @@ If you are discord and wish for this to be taken down, please message me at hell
 	--rscb-no-jump-chat: 0;
 }
 
+/* Alert message */
+#bd-notices{
+    z-index: 10000;
+}
+
 /* User modal */
 .visual-refresh .panels_c48ade, .visual-refresh .panels__5e434 {
 	right: var(--space-xs) !important;
@@ -52,7 +57,7 @@ If you are discord and wish for this to be taken down, please message me at hell
 	z-index: 200 !important;
 }
 
-/* Remove top row*/
+/* Remove top row */
 .visual-refresh .base_c48ade, .visual-refresh .base__5e434 {
 	grid-template-rows: [top] 0 [titleBarEnd] min-content [noticeEnd] 1fr [end];
 }


### PR DESCRIPTION
This will add z-index css to the alert so the nav buttons won't overlap it anymore.

Before:
<img width="1462" height="93" alt="before" src="https://github.com/user-attachments/assets/41c3b39d-6520-4d67-8299-6843f7426d24" />

After:
<img width="1440" height="87" alt="after" src="https://github.com/user-attachments/assets/c67c9b0d-6064-4f4d-8d8c-4def711bd8bd" />